### PR TITLE
Add 'rr get-binary' to run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -11,6 +11,7 @@ do
   cd $dir
   rm -rf ./vendor/spiral/shared
   composer update
+  ./vendor/bin/rr get-binary
   echo "Clear cache"
   rm -rf ./runtime/*
   cd ../


### PR DESCRIPTION
This PR fixes "chmod: ./rr: No such file or directory" in docker container